### PR TITLE
refactor!: Remove unused and deprecated code

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/nativemarket/NativeMarket.java
+++ b/android/src/main/java/com/getcapacitor/community/nativemarket/NativeMarket.java
@@ -3,7 +3,6 @@ package com.getcapacitor.community.nativemarket;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import com.getcapacitor.NativePlugin;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -31,7 +30,7 @@ public class NativeMarket extends Plugin {
         call.reject("appId is missing");
       }
     } catch (Exception ex) {
-      call.error(ex.getLocalizedMessage());
+      call.reject(ex.getLocalizedMessage());
     }
   }
 
@@ -54,7 +53,7 @@ public class NativeMarket extends Plugin {
         call.reject("devId is missing");
       }
     } catch (Exception ex) {
-      call.error(ex.getLocalizedMessage());
+      call.reject(ex.getLocalizedMessage());
     }
   }
 
@@ -77,7 +76,7 @@ public class NativeMarket extends Plugin {
         call.reject("name is missing");
       }
     } catch (Exception ex) {
-      call.error(ex.getLocalizedMessage());
+      call.reject(ex.getLocalizedMessage());
     }
   }
 
@@ -102,7 +101,7 @@ public class NativeMarket extends Plugin {
         call.reject("editorChoice is missing");
       }
     } catch (Exception ex) {
-      call.error(ex.getLocalizedMessage());
+      call.reject(ex.getLocalizedMessage());
     }
   }
 
@@ -125,7 +124,7 @@ public class NativeMarket extends Plugin {
         call.reject("terms is missing");
       }
     } catch (Exception ex) {
-      call.error(ex.getLocalizedMessage());
+      call.reject(ex.getLocalizedMessage());
     }
   }
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -9,21 +9,14 @@ import Capacitor
 public class NativeMarket: CAPPlugin {
     
     @objc func openStoreListing(_ call: CAPPluginCall) {
-        if call.hasOption("appId") {
-            let appId = call.getString("appId")
-            
-            let url = "itms-apps://itunes.apple.com/app/" + appId!
+        if let appId = call.getString("appId") {
+            let url = "itms-apps://itunes.apple.com/app/" + appId
             let appUrl = URL(string: url)
             
             DispatchQueue.main.async {
                 if UIApplication.shared.canOpenURL(appUrl!) {
-                    if #available(iOS 10.0, *) {
-                        UIApplication.shared.open(appUrl!, options: [:]) { (success) in
-                            call.success()
-                        }
-                    } else {
-                        UIApplication.shared.openURL(appUrl!)
-                        call.success()
+                    UIApplication.shared.open(appUrl!, options: [:]) { (success) in
+                        call.resolve()
                     }
                 }
             }
@@ -33,32 +26,25 @@ public class NativeMarket: CAPPlugin {
     }
     
     @objc func openDevPage(_ call: CAPPluginCall) {
-        call.success() // TODO: Implement
+        call.resolve() // TODO: Implement
     }
     
     @objc func openCollection(_ call: CAPPluginCall) {
-        call.success() // TODO: Implement
+        call.resolve() // TODO: Implement
     }
     
     @objc func openEditorChoicePage(_ call: CAPPluginCall) {
-        call.success() // TODO: Implement
+        call.resolve() // TODO: Implement
     }
     
     @objc func search(_ call: CAPPluginCall) {
-        if call.hasOption("terms") {
-            let terms = call.getString("terms")
-            
-            let url = "itms-apps://itunes.apple.com/search?term=" + terms!
+        if let terms = call.getString("terms") {
+            let url = "itms-apps://itunes.apple.com/search?term=" + terms
             let appUrl = URL(string: url)
             
             if UIApplication.shared.canOpenURL(appUrl!) {
-                if #available(iOS 10.0, *) {
-                    UIApplication.shared.open(appUrl!, options: [:]) { (success) in
-                        call.success()
-                    }
-                } else {
-                    UIApplication.shared.openURL(appUrl!)
-                    call.success()
+                UIApplication.shared.open(appUrl!, options: [:]) { (success) in
+                    call.resolve()
                 }
             }
         } else {


### PR DESCRIPTION
Will not merge until next major as it could be considered breaking.

Replace `call.error` with `call.reject`.
Replace `call.success` with `call.resolve`
Remove old code for iOS < 10
Remove deprecated `call.hasOption`
